### PR TITLE
formatting spacing between header tags and titles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-#Commiting to Flarepie
+# Commiting to Flarepie
 
 Flarepie is a open-sourced project and we are waiting for your contributions! 🎉
 
@@ -9,14 +9,14 @@ You can support Flarepie by contributing in the following areas:
 ⚡ **Optimization**
 📖 **Documentation**
 
-#How to Commit?
+# How to Commit?
 
 ##**1️⃣ Forking Flarepie**
 1. Go to Flarepie Repository (https://github.com/Elexs1zz/FlarePie)
 2. Click the "Fork" button in top right corner
 3. This will copy the project into your account!
 
-##**2️⃣ Create a New Branch**  
+## **2️⃣ Create a New Branch**  
 Before making contributions to the repository you forked, you need to open a new branch.
 
 📌 **Type these codes by using a Terminal or Git Bash**
@@ -25,7 +25,7 @@ Before making contributions to the repository you forked, you need to open a new
 3. **cd FlarePie**
 4. **git checkout -b new-feature**
 
-##**3️⃣ Make Changes and Commit**  
+## **3️⃣ Make Changes and Commit**  
 After making neceserry changes to the code, you need to commit it.
 
 📌 **How to Commit**
@@ -34,14 +34,14 @@ After making neceserry changes to the code, you need to commit it.
    
 Write your commit message meaningful and explanatory
 
-##**4️⃣ Push to the Repository You Forked**
+## **4️⃣ Push to the Repository You Forked**
 To commit changes to the forked repo on GitHub:
 
 1. **git push origin new-feature**
    
 This will push the branch to the repository in your GitHub account.
 
-##**5️⃣ Open a Pull Request**
+## **5️⃣ Open a Pull Request**
 1. Go to GitHub and create your own repository
 2. Click  the **"Compare & pull request"** button.
 3. Explain your changes on the page that opens.


### PR DESCRIPTION
Header and subheader definitions failed to produce expected outcome due to missing spacing. Adding spacing between the hashtags and titles in order to produce desired outcome.